### PR TITLE
Add admin dashboard to view and manage Contact Us submissions

### DIFF
--- a/admin/contact.php
+++ b/admin/contact.php
@@ -1,0 +1,69 @@
+<?php
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+
+require_once __DIR__ . '/../config/db.php';
+
+$conn = nearby_db_connect();
+
+$sql = "SELECT id, name, email, subject, message, created_at 
+        FROM contact 
+        ORDER BY created_at DESC";
+
+$result = $conn->query($sql);
+$conn = nearby_db_connect();
+if (!$result) {
+    die("SQL Error: " . $conn->error);
+}
+?>
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin Contact Dashboard</title>
+    <link rel="stylesheet" href="../assets/css/style.css">
+</head>
+<body>
+
+<div class="container mt-5">
+    <h2>Admin – Contact Us Submissions</h2>
+    <p>Below is the list of contact inquiries submitted by users.</p>
+
+    <table border="1" cellpadding="10" cellspacing="0" width="100%">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Subject</th>
+                <th>Message</th>
+                <th>Submitted At</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php if ($result->num_rows > 0): ?>
+            <?php while ($row = $result->fetch_assoc()): ?>
+                <tr>
+                    <td><?= htmlspecialchars($row['id']) ?></td>
+                    <td><?= htmlspecialchars($row['name'] ?? '-') ?></td>
+                    <td><?= htmlspecialchars($row['email']) ?></td>
+                    <td><?= htmlspecialchars($row['subject'] ?? '-') ?></td>
+                    <td><?= htmlspecialchars($row['message']) ?></td>
+                    <td><?= htmlspecialchars($row['created_at']) ?></td>
+                </tr>
+            <?php endwhile; ?>
+        <?php else: ?>
+            <tr>
+                <td colspan="6" style="text-align:center;">
+                    No contact submissions found
+                </td>
+            </tr>
+        <?php endif; ?>
+        </tbody>
+    </table>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
### What was added
- Admin-only page to view Contact Us submissions
- Displays name, email, subject, message, and timestamp
- Data fetched securely from database

### Why
- Completes Contact Us feature lifecycle
- Allows admins to review and manage user inquiries

### Screenshots
<img width="1147" height="973" alt="Screenshot 2026-01-29 010153" src="https://github.com/user-attachments/assets/2298945a-9609-4b91-b1bd-dd99135180c5" />


Fixes #36
