### PR TITLE
fix: remove unresolved merge conflict marker from footer (Issue #67)

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -122,7 +122,6 @@
     </div>
 </footer>
 
-<<<<<<< HEAD
 <?php if (!empty($enableChatbot)): ?>
     <?php include __DIR__ . '/chatbot-widget.php'; ?>
 <?php endif; ?>
@@ -188,9 +187,5 @@ backToTopBtn.addEventListener('click', () => {
 <button class="back-to-top" id="backToTop" aria-label="Back to top">
     <i class="bi bi-arrow-up"></i>
 </button>
-
 </body>
-
-
-
 </html>


### PR DESCRIPTION
## 🐞 Issue
The footer section was displaying an unresolved Git merge conflict marker:
<<<<<<< HEAD

This marker was visible on the live website and negatively impacted UI and professionalism.

## ✅ Fix Applied
- Removed the leftover merge conflict marker from `includes/footer.php`
- Verified that footer layout and scripts render correctly
- Tested dark mode toggle and back-to-top functionality

## 📌 Result
Footer now renders cleanly without any debug or merge-related text.

Closes #67 
