### PR TITLE
feat(navbar): add active page indicator styling (#120)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -128,6 +128,26 @@ a:hover {
     color: var(--nearby-accent);
 }
 
+/* ===== ACTIVE NAVBAR INDICATOR (#120) ===== */
+
+.navbar-nav .nav-link.active {
+    color: var(--nearby-accent) !important;
+    font-weight: 600;
+    position: relative;
+}
+
+/* underline indicator */
+.navbar-nav .nav-link.active::after {
+    content: "";
+    position: absolute;
+    left: 10%;
+    bottom: -4px;
+    width: 80%;
+    height: 2px;
+    background: var(--nearby-accent);
+    border-radius: 2px;
+}
+
 /* ===== TEXT LOGO STYLE ===== */
 
 .logo-text {


### PR DESCRIPTION
## Summary
Adds visual styling to highlight the active page in the navbar.

## Changes
- Added `.navbar-nav .nav-link.active` styling
- Added underline indicator using `::after`
- Uses existing active detection logic in `assets/js/main.js`

## Result
The active page is now clearly highlighted in the navbar, improving navigation clarity and user experience.

Closes #120 