### PR TITLE
fix(footer): remove oversized logo and balance footer layout (#119)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -331,3 +331,18 @@ textarea:focus {
         height: 50px;
     }
 }
+
+/* ===== Footer Layout Fix (#119) ===== */
+
+.footer-logo {
+    max-width: 120px;
+}
+
+.glass-footer {
+    padding-top: 40px;
+    padding-bottom: 20px;
+}
+
+.footer-top {
+    align-items: flex-start;
+}

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -2,11 +2,11 @@
 </main>
 <footer class="glass-footer py-5 mt-auto">
     <div class="container">
-        <div class="row gy-4 align-items-start footer-top">
-            <div class="col-lg-3 text-center text-lg-start">
-                <div class="d-inline-flex align-items-center gap-3 mb-3">
-                    <img src="assets/images/nearby_image.png" alt="NearBy logo" class="footer-logo">
-                </div>
+        <div class="row g-4 align-items-start footer-top">
+            <div class="col-lg-3 col-md-6 text-center text-lg-start">
+                <div class="mb-3">
+    <a href="index.php" class="logo-text">NearBy</a>
+</div>
                 <p class="footer-copy mb-3">
                     Discover vetted rooms, apartments, and co-living spaces designed for students and young
                     professionals.


### PR DESCRIPTION
## Summary
Fixes footer layout imbalance caused by the oversized NearBy logo.

## Changes
- Removed large footer image logo
- Replaced it with text logo consistent with navbar
- Improved column spacing
- Reduced excessive footer height
- Improved responsive layout

## Result
Footer now has better visual hierarchy, cleaner proportions, and improved responsiveness.

<img width="1919" height="955" alt="image" src="https://github.com/user-attachments/assets/fdaaa67f-7007-44ad-9c17-c96008689d9b" />

Closes #119 