### PR TITLE
Fix Chat Widget Button Overlapping UI (#141)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -528,6 +528,8 @@ textarea:focus {
 .featured-card:hover .featured-image {
     transform: scale(1.04);
     transition: transform 0.35s ease;
+}
+
 /* ===== Footer Layout Fix (#119) ===== */
 
 .footer-logo {
@@ -541,7 +543,7 @@ textarea:focus {
 
 .footer-top {
     align-items: flex-start;
-}}
+}
 /* ===== NAVBAR LAYOUT ALIGNMENT FIX ===== */
 
 /* Push everything except logo to the right */
@@ -557,4 +559,93 @@ textarea:focus {
 /* Keep logo clearly on the left */
 .logo-text {
     margin-right: auto;
+}
+
+/* ===== CHATBOT POSITION FIX (#141) ===== */
+
+.chatbot-entry {
+    position: fixed !important;
+    bottom: 24px !important;
+    right: 24px !important;
+    left: auto !important;
+    z-index: 1200;
+}
+
+/* Fix toggle button positioning */
+.chatbot-toggle {
+    position: relative;
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Ensure panel opens above button */
+.chatbot-panel {
+    position: absolute;
+    bottom: 70px;
+    right: 0;
+}
+
+/* Mobile adjustment */
+@media (max-width: 768px) {
+    .chatbot-entry {
+        bottom: 20px !important;
+        right: 16px !important;
+    }
+}
+
+/* Chat button style */
+.chatbot-toggle {
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Mobile adjustment */
+@media (max-width: 768px) {
+    .chatbot-entry {
+        bottom: 20px;
+        right: 16px;
+    }
+}
+
+/* ===== FORCE CHATBOT FIX (#141) ===== */
+
+body div.chatbot-entry {
+    position: fixed !important;
+    bottom: 24px !important;
+    right: 24px !important;
+    left: auto !important;
+    z-index: 2000 !important;
+}
+
+/* Chat button styling */
+body div.chatbot-entry .chatbot-toggle {
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Chat panel position */
+body div.chatbot-entry .chatbot-panel {
+    position: absolute;
+    bottom: 70px;
+    right: 0;
+}
+
+/* Mobile fix */
+@media (max-width: 768px) {
+    body div.chatbot-entry {
+        bottom: 20px !important;
+        right: 16px !important;
+    }
 }


### PR DESCRIPTION
## Fix Chat Widget Button Overlapping UI (#141)

This PR fixes the positioning issue of the chatbot widget where the floating button appeared partially outside the viewport and overlapped UI elements.

### Changes
- Repositioned chatbot widget to the bottom-right corner
- Added stronger CSS selector to override conflicting styles
- Improved responsive behavior for mobile screens
- Ensured widget remains fully visible and clickable

### Files Modified
- assets/css/style.css

This resolves the UI issue and improves usability of the chat assistant.

Closes #141 