### PR TITLE
Remove Duplicate "Post Product / Post Your Item" Buttons (#147)

### DIFF
--- a/second-hand-products.php
+++ b/second-hand-products.php
@@ -137,18 +137,6 @@ require_once __DIR__ . '/includes/header.php';
             <option value="price_low">Price: Low → High</option>
             <option value="price_high">Price: High → Low</option>
         </select>
-
-        <button
-            class="btn btn-success"
-            type="button"
-            data-bs-toggle="modal"
-            data-bs-target="#postProductModal">
-
-            <i class="bi bi-plus-circle me-2"></i>
-            Post Product
-
-        </button>
-
     </div>
 
             <div class="d-flex justify-content-between align-items-center mb-4">


### PR DESCRIPTION
Fixes duplicate posting buttons on the Second-Hand Products page.

Changes:
- Removed redundant "Post Product" button
- Kept a single clear CTA button
- Improved UI clarity and layout

Closes #147 