### PR TITLE
Fix sorting functionality on Second-Hand Products page

### DIFF
--- a/api/fetch_products.php
+++ b/api/fetch_products.php
@@ -29,6 +29,7 @@ $condition = $_GET['condition'] ?? null;
 $search = $_GET['search'] ?? null;
 $limit = isset($_GET['limit']) ? (int)$_GET['limit'] : 20;
 $offset = isset($_GET['offset']) ? (int)$_GET['offset'] : 0;
+$sort = $_GET['sort'] ?? 'latest';
 
 // Build query
 $query = "SELECT p.*, 'Student Seller' as seller_name FROM products p WHERE 1=1";
@@ -64,7 +65,23 @@ if ($search) {
 }
 
 // Add ordering and pagination
-$query .= " ORDER BY p.created_at DESC LIMIT ? OFFSET ?";
+// Apply sorting
+switch ($sort) {
+
+    case 'price_low':
+        $query .= " ORDER BY p.price ASC";
+        break;
+
+    case 'price_high':
+        $query .= " ORDER BY p.price DESC";
+        break;
+
+    case 'latest':
+    default:
+        $query .= " ORDER BY p.created_at DESC";
+}
+
+$query .= " LIMIT ? OFFSET ?";
 $params[] = $limit;
 $params[] = $offset;
 $types .= "ii";


### PR DESCRIPTION
Closes #168

Fixed the sorting feature on the Second-Hand Products page.

Changes:
- Added support for `sort` parameter in fetch_products.php
- Implemented sorting logic for:
  - Latest
  - Price Low → High
  - Price High → Low
- Ensured sorting works with existing filters and pagination.

Products now reorder correctly when the sort option is changed.

Closes #168 