### PR TITLE
Fix: Products not appearing on Second-Hand page (#167)

### DIFF
--- a/api/fetch_products.php
+++ b/api/fetch_products.php
@@ -77,8 +77,8 @@ switch ($sort) {
         break;
 
     case 'latest':
-    default:
-        $query .= " ORDER BY p.created_at DESC";
+default:
+    $query .= " ORDER BY COALESCE(p.created_at, NOW()) DESC";
 }
 
 $query .= " LIMIT ? OFFSET ?";
@@ -106,6 +106,7 @@ try {
             'description' => $row['description'],
             'contact_phone' => $row['contact_phone'],
             'image_url' => $row['image_url'],
+            'image' => $row['image_url'],
             'seller_name' => $row['seller_name'],
             'created_at' => $row['created_at']
         ];


### PR DESCRIPTION
This PR fixes an issue where newly added products were not appearing correctly on the Second-Hand page.

Changes:
- Improved latest sorting using COALESCE to handle NULL created_at values
- Added image alias to support frontend rendering compatibility

These changes ensure products are reliably returned and displayed.

Closes #167 