### PR TITLE
Fix #180: Document live demo hosting issue and add local setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,3 +404,25 @@ Thanks to:
 ---
 
 **NearBy** – *Helping students find a place and feel at home.* 🌟
+
+## Live Demo Status
+
+The live demo hosted at:
+
+https://sumitrathor.rf.gd/nearby/
+
+may currently return a **502 Bad Gateway** error or **connection timeout** due to hosting server limitations.
+
+The project itself works correctly when run locally.
+
+### Running the Project Locally
+
+1. Install **XAMPP**
+2. Clone the repository
+3. Move the project folder into the `htdocs` directory
+4. Start **Apache** and **MySQL** from the XAMPP Control Panel
+5. Open the following URL in your browser:
+
+http://localhost/nearby/
+
+Running the project locally allows contributors to test features even if the live demo is temporarily unavailable.


### PR DESCRIPTION
## Fix for Issue #180 – Live Demo Link Not Working

### Summary

The live demo currently returns a **502 Bad Gateway / connection timeout** due to hosting issues.

### Investigation

The project was tested locally using XAMPP and it runs correctly at:

http://localhost/nearby/

This confirms that the issue is related to the hosting server rather than the project code.

### Changes Made

* Added a **Live Demo Status** section in `README.md`
* Documented the hosting issue
* Added instructions for running the project locally

### Result

Contributors can now run the project locally even if the live demo is temporarily unavailable.

Fixes #180
